### PR TITLE
chore(ci): use Chainguard action mirrors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,10 +34,10 @@ jobs:
         cache: false
 
     - name: Set up QEMU dependency
-      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0
+      uses: chainguard-actions/docker-setup-qemu-action@be526888acc63b74559c57bb8b34a420f2a24670 # v4.1.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
+      uses: chainguard-actions/docker-setup-buildx-action@b6beb8a80a92c55017146dc002f047479d776a98 # v4.1.0
 
     - name: Setup dependencies
       run: sudo apt update && sudo apt install -y util-linux udev parted e2fsprogs mount tar extlinux qemu-utils qemu-system
@@ -87,10 +87,10 @@ jobs:
         cache: false
 
     - name: Set up QEMU dependency
-      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0
+      uses: chainguard-actions/docker-setup-qemu-action@be526888acc63b74559c57bb8b34a420f2a24670 # v4.1.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
+      uses: chainguard-actions/docker-setup-buildx-action@b6beb8a80a92c55017146dc002f047479d776a98 # v4.1.0
 
     - name: Setup dependencies
       run: sudo apt update && sudo apt install -y util-linux udev parted e2fsprogs mount tar extlinux qemu-utils qemu-system
@@ -136,10 +136,10 @@ jobs:
         cache: false
 
     - name: Set up QEMU dependency
-      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0
+      uses: chainguard-actions/docker-setup-qemu-action@be526888acc63b74559c57bb8b34a420f2a24670 # v4.1.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
+      uses: chainguard-actions/docker-setup-buildx-action@b6beb8a80a92c55017146dc002f047479d776a98 # v4.1.0
 
     - name: Setup dependencies
       run: sudo apt update && sudo apt install -y util-linux udev parted e2fsprogs mount tar extlinux qemu-utils qemu-system ovmf
@@ -211,13 +211,13 @@ jobs:
         cache: false
 
     - name: Set up QEMU dependency
-      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0
+      uses: chainguard-actions/docker-setup-qemu-action@be526888acc63b74559c57bb8b34a420f2a24670 # v4.1.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
+      uses: chainguard-actions/docker-setup-buildx-action@b6beb8a80a92c55017146dc002f047479d776a98 # v4.1.0
 
     - name: Login to Docker Hub
-      uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1
+      uses: chainguard-actions/docker-login-action@2ec1a61ac7d5854002f4e3df1f32cc1d02994f76 # v4.2.0
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -274,13 +274,13 @@ jobs:
         cache: false
 
     - name: Set up QEMU dependency
-      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0
+      uses: chainguard-actions/docker-setup-qemu-action@be526888acc63b74559c57bb8b34a420f2a24670 # v4.1.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
+      uses: chainguard-actions/docker-setup-buildx-action@b6beb8a80a92c55017146dc002f047479d776a98 # v4.1.0
 
     - name: Login to Docker Hub
-      uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1
+      uses: chainguard-actions/docker-login-action@2ec1a61ac7d5854002f4e3df1f32cc1d02994f76 # v4.2.0
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -382,13 +382,13 @@ jobs:
         cache: false
 
     - name: Set up QEMU dependency
-      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0
+      uses: chainguard-actions/docker-setup-qemu-action@be526888acc63b74559c57bb8b34a420f2a24670 # v4.1.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
+      uses: chainguard-actions/docker-setup-buildx-action@b6beb8a80a92c55017146dc002f047479d776a98 # v4.1.0
 
     - name: Login to Docker Hub
-      uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1
+      uses: chainguard-actions/docker-login-action@2ec1a61ac7d5854002f4e3df1f32cc1d02994f76 # v4.2.0
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,7 +20,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
+      uses: chainguard-actions/docker-setup-buildx-action@b6beb8a80a92c55017146dc002f047479d776a98 # v4.1.0
     - name: Build and deploy mkdocs site
       run: |
         git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

Migrates GitHub Actions references in this repo to SHA-pinned `chainguard-actions/*` mirrors.

- Migratable hits: 16
- Distinct upstream actions: 3
- Exact tag migrations: 0
- Closest-tag fallback migrations: 16

## Actions

- `docker/login-action`
- `docker/setup-buildx-action`
- `docker/setup-qemu-action`

## Notes

This PR is part of the org-wide Chainguard Actions migration. The final Terraform allowlist cleanup PR is a draft and should merge only after all downstream migration PRs listed there have merged.
