### PR TITLE
chore(ci): migrate action pins off removed allowlist entries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -239,7 +239,7 @@ jobs:
 
     - name: Import GPG key
       id: import_gpg
-      uses: crazy-max/ghaction-import-gpg@e00cb83a68c1158b29afc5217dd0582cada6d172 # v4.4.0
+      uses: step-security/ghaction-import-gpg@c0b4a334b9b72bfaaebec86ef022a78a5b17f828 # v7.0.0
       if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
       with:
         gpg_private_key: ${{ secrets.GPG_KEY }}
@@ -342,7 +342,7 @@ jobs:
 
     - name: Import GPG key
       id: import_gpg
-      uses: crazy-max/ghaction-import-gpg@e00cb83a68c1158b29afc5217dd0582cada6d172 # v4.4.0
+      uses: step-security/ghaction-import-gpg@c0b4a334b9b72bfaaebec86ef022a78a5b17f828 # v7.0.0
       with:
         gpg_private_key: ${{ secrets.GPG_KEY }}
         passphrase: ${{ secrets.GPG_PASSWORD }}


### PR DESCRIPTION
## Why

Part of re-landing magicproduct/terraform#16088 (removal of 209 migrated action SHAs from the org actions allowlist, reverted in #16639 because workflows still reached removed entries transitively). A verified org-wide transitive scan found this repo's default-branch workflows reach removed entries through the pins bumped here. Once every repo is clean the allowlist removal re-lands; without this bump, affected workflows will fail at startup with "actions ... are not allowed" when that happens.

All new pins point at the current secure versions (magic actions rebuilt on chainguard-actions/step-security mirrors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
